### PR TITLE
Add flags to emit metal shader and list kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ To try out the project, clone the repository and follow these steps:
 
 1. **Compile the Project**: Use `cargo build` to compile the Rust code.
 2. **Run a Kernel**: Use `cd src` and `cargo run -- -i examples/vector_add.cu -d output/ --run -v` to translate and execute a CUDA kernel.
+3. **Inspect the AST**: Add `--print-ast` to print the parsed Abstract Syntax Tree.
+4. **Print Metal Code**: Use `--emit-metal` to print the generated Metal shader.
+5. **List Kernels**: Add `--list-kernels` to display detected kernel names.
 
 ## Core Components
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,18 @@ struct Args {
     // run the kernel after generation
     #[arg(short, long)]
     run: bool,
+
+    /// Print the parsed Abstract Syntax Tree to stdout
+    #[arg(long)]
+    print_ast: bool,
+
+    /// Print the generated Metal shader to stdout
+    #[arg(long)]
+    emit_metal: bool,
+
+    /// List kernels found in the input file
+    #[arg(long)]
+    list_kernels: bool,
 }
 
 fn validate_input(path: &PathBuf) -> Result<()> {
@@ -178,6 +190,18 @@ fn main() -> Result<()> {
         }
     }
 
+    if args.list_kernels {
+        print_section_header("Kernels");
+        for kernel in &cuda_program.device_code {
+            println!("{}", kernel.name);
+        }
+    }
+
+    if args.print_ast {
+        print_section_header("AST Dump");
+        println!("{:#?}", cuda_program);
+    }
+
     // Generate Metal shader
     print_section_header("Metal Translation");
     let mut metal_shader = metal::MetalShader::new();
@@ -217,6 +241,11 @@ fn main() -> Result<()> {
     log::info!("   ├─ Dimensions: {}", dimensions);
     log::info!("   ├─ Grid size: {:?}", config.grid_size);
     log::info!("   └─ Thread group size: {:?}", config.threadgroup_size);
+
+    if args.emit_metal {
+        print_section_header("Metal Shader");
+        println!("{}", metal_shader.source());
+    }
 
     // Write Metal shader
     print_section_header("File Generation");

--- a/tests/emit_metal.rs
+++ b/tests/emit_metal.rs
@@ -1,0 +1,11 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn prints_metal_when_flag_set() {
+    let mut cmd = Command::cargo_bin("cudapple").unwrap();
+    cmd.current_dir("src")
+        .args(["-i", "examples/vector_add.cu", "-d", "../tmp_output", "--emit-metal"]);
+    cmd.assert()
+        .stdout(predicate::str::contains("#include <metal_stdlib>"));
+}

--- a/tests/list_kernels.rs
+++ b/tests/list_kernels.rs
@@ -1,0 +1,11 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn lists_kernels_when_flag_set() {
+    let mut cmd = Command::cargo_bin("cudapple").unwrap();
+    cmd.current_dir("src")
+        .args(["-i", "examples/vector_add.cu", "-d", "../tmp_output", "--list-kernels"]);
+    cmd.assert()
+        .stdout(predicate::str::contains("vectorAdd"));
+}

--- a/tests/print_ast.rs
+++ b/tests/print_ast.rs
@@ -1,0 +1,11 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn prints_ast_when_flag_set() {
+    let mut cmd = Command::cargo_bin("cudapple").unwrap();
+    cmd.current_dir("src")
+        .args(["-i", "examples/vector_add.cu", "-d", "../tmp_output", "--print-ast"]);
+    cmd.assert()
+        .stdout(predicate::str::contains("CudaProgram"));
+}


### PR DESCRIPTION
## Summary
- introduce `--emit-metal` flag to print generated Metal shader
- introduce `--list-kernels` flag to list kernel names
- document both new flags in README
- add integration tests for the two flags

## Testing
- `cargo test --quiet` *(fails: failed to download `anyhow`)*
- `cargo fmt` *(fails: rustfmt component not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684210eb812483269dcb4ef2562a4d26