### PR TITLE
Add --emit-host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ To try out the project, clone the repository and follow these steps:
 3. **Inspect the AST**: Add `--print-ast` to print the parsed Abstract Syntax Tree.
 4. **Print Metal Code**: Use `--emit-metal` to print the generated Metal shader.
 5. **List Kernels**: Add `--list-kernels` to display detected kernel names.
+6. **Print Swift Host Code**: Use `--emit-host` to print the generated Swift files.
 
 ## Core Components
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,10 @@ struct Args {
     #[arg(long)]
     emit_metal: bool,
 
+    /// Print the generated Swift host code to stdout
+    #[arg(long)]
+    emit_host: bool,
+
     /// List kernels found in the input file
     #[arg(long)]
     list_kernels: bool,
@@ -264,14 +268,20 @@ fn main() -> Result<()> {
 
     // Write Swift host code
     let host_path = args.output.join("MetalKernelRunner.swift");
-    fs::write(&host_path, swift_runner_code).context("Failed to write Swift host code")?;
+    fs::write(&host_path, &swift_runner_code).context("Failed to write Swift host code")?;
 
     let main_path = args.output.join("main.swift");
-    fs::write(&main_path, swift_main_code).context("Failed to write Swift main code")?;
+    fs::write(&main_path, &swift_main_code).context("Failed to write Swift main code")?;
 
     log::info!("✓ Written Swift files:");
     log::info!("   ├─ {:?}", host_path);
     log::info!("   └─ {:?}", main_path);
+
+    if args.emit_host {
+        print_section_header("Swift Host");
+        println!("-- MetalKernelRunner.swift --\n{}", swift_runner_code);
+        println!("-- main.swift --\n{}", swift_main_code);
+    }
 
     // If --run flag is present, compile and execute the kernel
     if args.run {

--- a/tests/emit_host.rs
+++ b/tests/emit_host.rs
@@ -1,0 +1,11 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn prints_host_when_flag_set() {
+    let mut cmd = Command::cargo_bin("cudapple").unwrap();
+    cmd.current_dir("src")
+        .args(["-i", "examples/vector_add.cu", "-d", "../tmp_output", "--emit-host"]);
+    cmd.assert()
+        .stdout(predicate::str::contains("import Metal"));
+}


### PR DESCRIPTION
## Summary
- add `--emit-host` flag to print the generated Swift files
- document new CLI option in the README
- test `--emit-host` using assert_cmd

## Testing
- `cargo test` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68542f1c5ab08326b65d20f91f8c9e4c